### PR TITLE
Protect access and set up colors for staff calendar

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,6 @@
 		"@fullcalendar/icalendar": "^6.1.15",
 		"@fullcalendar/list": "^6.1.15",
 		"@fullcalendar/timegrid": "^6.1.15",
-		"@marko19907/string-to-color": "^1.0.0",
 		"@types/color-hash": "^1.0.5",
 		"@types/js-cookie": "^3.0.6",
 		"@types/leaflet": "^1.9.16",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@fullcalendar/timegrid':
         specifier: ^6.1.15
         version: 6.1.15(@fullcalendar/core@6.1.15)
-      '@marko19907/string-to-color':
-        specifier: ^1.0.0
-        version: 1.0.0
       '@types/color-hash':
         specifier: ^1.0.5
         version: 1.0.5
@@ -452,9 +449,6 @@ packages:
   '@maplibre/maplibre-gl-style-spec@20.4.0':
     resolution: {integrity: sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==}
     hasBin: true
-
-  '@marko19907/string-to-color@1.0.0':
-    resolution: {integrity: sha512-V3ipYiIUhYjP7BqpOY06mgRFFGoR9cKawD4iJQFhEnuy3j3e0ipcr+OpNQLbOBrIU3p9wuPw3OwBn0hHopDW0A==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1201,9 +1195,6 @@ packages:
 
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
-
-  esm-seedrandom@3.0.5:
-    resolution: {integrity: sha512-pMAq0mFIr5JQ3Ihbng7EBLMJ+llMbaDKkiG44pqbSXS0NIZWtEANpOpxb5s6Q8Q2R562P26qMHPv8YtP/NHh9g==}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -2726,10 +2717,6 @@ snapshots:
       rw: 1.3.3
       tinyqueue: 3.0.0
 
-  '@marko19907/string-to-color@1.0.0':
-    dependencies:
-      esm-seedrandom: 3.0.5
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3497,8 +3484,6 @@ snapshots:
       - supports-color
 
   esm-env@1.2.2: {}
-
-  esm-seedrandom@3.0.5: {}
 
   espree@9.6.1:
     dependencies:

--- a/frontend/src/lib/calendar.test.ts
+++ b/frontend/src/lib/calendar.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { CalendarSet } from '$lib/calendar';
+
+describe('calendar event details', () => {
+	it('preserves the description and location from an ICS event', () => {
+		const calendar = CalendarSet.cleanAndParse(
+			[
+				'BEGIN:VCALENDAR',
+				'VERSION:2.0',
+				'PRODID:-//Makerspace//Calendar test//EN',
+				'BEGIN:VEVENT',
+				'UID:tour-test@example.com',
+				'DTSTAMP:20260831T120000Z',
+				'DTSTART:20260923T140000Z',
+				'DTEND:20260923T150000Z',
+				'SUMMARY:Prospective student tour',
+				'DESCRIPTION:Meet the group at the front desk.',
+				'LOCATION:Agricultural Engineering 120',
+				'SEQUENCE:0',
+				'END:VEVENT',
+				'END:VCALENDAR',
+				''
+			].join('\r\n')
+		);
+
+		const events = calendar.between(
+			new Date('2026-09-23T00:00:00Z'),
+			new Date('2026-09-24T00:00:00Z')
+		);
+
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			title: 'Prospective student tour',
+			description: 'Meet the group at the front desk.',
+			location: 'Agricultural Engineering 120'
+		});
+	});
+
+	it('omits excluded instances from a recurring event', () => {
+		const calendar = CalendarSet.cleanAndParse(
+			[
+				'BEGIN:VCALENDAR',
+				'VERSION:2.0',
+				'PRODID:-//Makerspace//Calendar test//EN',
+				'BEGIN:VEVENT',
+				'UID:recurring-shift@example.com',
+				'DTSTAMP:20260831T120000Z',
+				'DTSTART:20260923T140000Z',
+				'DTEND:20260923T150000Z',
+				'RRULE:FREQ=DAILY;COUNT=3',
+				'EXDATE:20260924T140000Z',
+				'SUMMARY:Shira',
+				'SEQUENCE:0',
+				'END:VEVENT',
+				'END:VCALENDAR',
+				''
+			].join('\r\n')
+		);
+
+		const events = calendar.between(
+			new Date('2026-09-23T00:00:00Z'),
+			new Date('2026-09-27T00:00:00Z')
+		);
+
+		expect(events.map((event) => event.start)).toEqual([
+			'2026-09-23T14:00:00.000Z',
+			'2026-09-25T14:00:00.000Z'
+		]);
+	});
+});

--- a/frontend/src/lib/calendar.ts
+++ b/frontend/src/lib/calendar.ts
@@ -2,12 +2,15 @@ import type { ICS } from '@filecage/ical';
 import type { DateTime } from '@filecage/ical/ValueTypes';
 import { parseString } from '@filecage/ical/parser';
 import { addDays, isWithinInterval, subDays } from 'date-fns';
-import RRULE from 'rrule';
+import RRULE, * as RRULENamespace from 'rrule';
 import tcal from 'tcal';
+
+const { RRule, RRuleSet } = (RRULE ?? RRULENamespace) as typeof import('rrule');
 
 export type EventJSON = {
 	title: string;
 	description?: string;
+	location?: string;
 	start: string;
 	end: string;
 	allDay: boolean;
@@ -36,19 +39,19 @@ export class TimezoneTransition {
 	public tzoffsetfrom: number;
 	public tzoffsetto: number;
 	public dtstart: Date;
-	public rrule?: RRULE.RRuleSet;
+	public rrule?: import('rrule').RRuleSet;
 
 	constructor(transition: ICS.TimezoneDefinition) {
 		this.tzoffsetfrom = getOffsetValue(transition.TZOFFSETFROM.value);
 		this.tzoffsetto = getOffsetValue(transition.TZOFFSETTO.value);
 		this.dtstart = transition.DTSTART.value.date;
 		if (transition.RRULE) {
-			const rrule = new RRULE.RRuleSet();
+			const rrule = new RRuleSet();
 
 			rrule.rrule(
-				new RRULE.RRule({
+				new RRule({
 					dtstart: this.dtstart,
-					...RRULE.RRule.parseString(transition.RRULE.value)
+					...RRule.parseString(transition.RRULE.value)
 				})
 			);
 
@@ -134,6 +137,7 @@ export type EventEndType =
 export class EventInstance {
 	public title: string;
 	public description: string;
+	public location: string;
 	public start: DateTime;
 	public end: EventEndType;
 	public allDay: boolean;
@@ -144,6 +148,7 @@ export class EventInstance {
 	constructor(event: Event, start: Date) {
 		this.title = event.title;
 		this.description = event.description || '';
+		this.location = event.location || '';
 		this.start = {
 			date: start,
 			isDateOnly: event.start.isDateOnly,
@@ -192,6 +197,7 @@ export class EventInstance {
 		return {
 			title: this.title,
 			description: this.description,
+			location: this.location,
 			start,
 			end: this.getEndTimeTimestamp(timezoneMap),
 			allDay: this.allDay,
@@ -207,6 +213,7 @@ export class EventInstance {
 export class Event {
 	public title: string;
 	public description?: string;
+	public location?: string;
 	public start: DateTime;
 	public end: EventEndType;
 	public allDay: boolean;
@@ -214,11 +221,12 @@ export class Event {
 	public sequence: number;
 	public recurrenceId?: DateTime;
 
-	public rrules?: RRULE.RRuleSet;
+	public rrules?: import('rrule').RRuleSet;
 
 	constructor(event: ICS.VEVENT.Published) {
 		this.title = event.SUMMARY.value;
 		this.description = event.DESCRIPTION?.value;
+		this.location = event.LOCATION?.value;
 
 		this.start = event.DTSTART.value;
 		if (!this.start.isUTC) {
@@ -264,15 +272,15 @@ export class Event {
 
 		this.allDay = event.DTSTART.value.isDateOnly;
 
-		const rrules = new RRULE.RRuleSet();
+		const rrules = new RRuleSet();
 		let useRrule = false;
 
 		if (event.RRULE) {
 			useRrule = true;
 			rrules.rrule(
-				new RRULE.RRule({
+				new RRule({
 					dtstart: this.start.date,
-					...RRULE.RRule.parseString(event.RRULE.value)
+					...RRule.parseString(event.RRULE.value)
 				})
 			);
 		}
@@ -282,8 +290,18 @@ export class Event {
 			throw new Error('RDATE not supported');
 		}
 
-		if (event.EXDATE && event.EXDATE.propertyList) {
-			event.EXDATE.propertyList.forEach((exdates) => {
+		if (event.EXDATE) {
+			// @filecage/ical declares EXDATE as an array, but 0.3.2 returns a property-list
+			// wrapper at runtime. Accept both shapes so exclusions remain correct across versions.
+			const exceptionDates: { value: DateTime[] }[] = Array.isArray(event.EXDATE)
+				? event.EXDATE
+				: (
+						event.EXDATE as unknown as {
+							propertyList: { value: DateTime[] }[];
+						}
+					).propertyList;
+
+			exceptionDates.forEach((exdates) => {
 				exdates.value.forEach((exdate) => {
 					rrules.exdate(floatingTZAdjust(exdate));
 				});

--- a/frontend/src/lib/calendarServer.test.ts
+++ b/frontend/src/lib/calendarServer.test.ts
@@ -22,7 +22,9 @@ describe('CalendarServer source cache', () => {
 		calendarMock.cleanAndParse.mockReturnValue({ between: calendarMock.between });
 	});
 
-	afterEach(() => vi.useRealTimers());
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
 	it('reuses the private ICS read for five minutes and then refreshes it', async () => {
 		const sourceFetch = vi.fn(async () => new Response('private ICS contents'));

--- a/frontend/src/lib/calendarServer.test.ts
+++ b/frontend/src/lib/calendarServer.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const calendarMock = vi.hoisted(() => ({
+	between: vi.fn(() => []),
+	cleanAndParse: vi.fn()
+}));
+
+vi.mock('$lib/calendar', () => ({
+	CalendarSet: {
+		cleanAndParse: calendarMock.cleanAndParse
+	}
+}));
+
+import { CalendarServer } from '$lib/calendarServer';
+
+describe('CalendarServer source cache', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-09-08T12:00:00Z'));
+		calendarMock.between.mockClear();
+		calendarMock.cleanAndParse.mockReset();
+		calendarMock.cleanAndParse.mockReturnValue({ between: calendarMock.between });
+	});
+
+	afterEach(() => vi.useRealTimers());
+
+	it('reuses the private ICS read for five minutes and then refreshes it', async () => {
+		const sourceFetch = vi.fn(async () => new Response('private ICS contents'));
+		const calendar = new CalendarServer(
+			'https://calendar.example/private.ics',
+			sourceFetch as typeof globalThis.fetch
+		);
+		const start = new Date('2026-09-08T00:00:00Z');
+		const end = new Date('2026-09-09T00:00:00Z');
+
+		await calendar.getEventsBetween(start, end);
+		vi.advanceTimersByTime(4 * 60 * 1000 + 59 * 1000);
+		await calendar.getEventsBetween(start, end);
+		expect(sourceFetch).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(2 * 1000);
+		await calendar.getEventsBetween(start, end);
+		expect(sourceFetch).toHaveBeenCalledTimes(2);
+		expect(calendarMock.cleanAndParse).toHaveBeenCalledTimes(2);
+	});
+});

--- a/frontend/src/lib/components/Calendar.svelte
+++ b/frontend/src/lib/components/Calendar.svelte
@@ -1,11 +1,75 @@
 <script lang="ts">
-	import { Calendar } from '@fullcalendar/core';
+	import { Calendar, type EventApi } from '@fullcalendar/core';
 	import dayGridPlugin from '@fullcalendar/daygrid';
 	import timeGridPlugin from '@fullcalendar/timegrid';
 	import listPlugin from '@fullcalendar/list';
+	import { Modal } from 'flowbite-svelte';
 	import './calendar.pcss';
 
 	export let url: string;
+	export let detailsEnabled = false;
+	export let fitWorkingHours = false;
+
+	type EventDetails = {
+		title: string;
+		description: string;
+		location: string;
+		start: Date | null;
+		end: Date | null;
+		allDay: boolean;
+	};
+
+	let detailsOpen = false;
+	let selectedEvent: EventDetails | null = null;
+
+	function openEventDetails(event: EventApi) {
+		if (!detailsEnabled) return;
+
+		selectedEvent = {
+			title: event.title || 'Untitled event',
+			description:
+				typeof event.extendedProps.description === 'string'
+					? event.extendedProps.description.trim()
+					: '',
+			location:
+				typeof event.extendedProps.location === 'string' ? event.extendedProps.location.trim() : '',
+			start: event.start,
+			end: event.end,
+			allDay: event.allDay
+		};
+		detailsOpen = true;
+	}
+
+	function isSameDay(first: Date, second: Date) {
+		return (
+			first.getFullYear() === second.getFullYear() &&
+			first.getMonth() === second.getMonth() &&
+			first.getDate() === second.getDate()
+		);
+	}
+
+	function formatEventTime(event: EventDetails) {
+		if (!event.start) return 'Time not specified';
+
+		const date = new Intl.DateTimeFormat(undefined, {
+			weekday: 'long',
+			month: 'long',
+			day: 'numeric',
+			year: 'numeric'
+		});
+		if (event.allDay) return `All day · ${date.format(event.start)}`;
+
+		const time = new Intl.DateTimeFormat(undefined, {
+			hour: 'numeric',
+			minute: '2-digit'
+		});
+		if (!event.end) return `${date.format(event.start)} · ${time.format(event.start)}`;
+		if (isSameDay(event.start, event.end)) {
+			return `${date.format(event.start)} · ${time.format(event.start)}–${time.format(event.end)}`;
+		}
+
+		return `${date.format(event.start)} ${time.format(event.start)} – ${date.format(event.end)} ${time.format(event.end)}`;
+	}
 
 	function calendarAction(element: HTMLElement) {
 		let calendar = new Calendar(element, {
@@ -20,7 +84,34 @@
 				right: 'dayGridMonth,timeGridWeek,listWeek'
 			},
 			nowIndicator: true,
-			scrollTime: new Date().getHours() + ':00:00'
+			scrollTime: fitWorkingHours ? '08:00:00' : new Date().getHours() + ':00:00',
+			...(fitWorkingHours
+				? {
+						height: 'auto' as const,
+						slotMinTime: '08:00:00',
+						slotMaxTime: '22:00:00'
+					}
+				: {}),
+			eventClick: ({ event, jsEvent }) => {
+				if (!detailsEnabled) return;
+				jsEvent.preventDefault();
+				openEventDetails(event);
+			},
+			eventDidMount: ({ el, event }) => {
+				if (!detailsEnabled) return;
+
+				el.tabIndex = 0;
+				el.setAttribute('role', 'button');
+				el.setAttribute('aria-label', `View details for ${event.title || 'untitled event'}`);
+				el.onkeydown = (keyEvent) => {
+					if (keyEvent.key !== 'Enter' && keyEvent.key !== ' ') return;
+					keyEvent.preventDefault();
+					openEventDetails(event);
+				};
+			},
+			eventWillUnmount: ({ el }) => {
+				el.onkeydown = null;
+			}
 		});
 
 		calendar.render();
@@ -34,7 +125,37 @@
 </script>
 
 <div
-	class="flex w-full justify-center divide-gray-100 border-gray-100 text-gray-700 dark:divide-gray-700 dark:border-gray-700 dark:text-gray-200 md:aspect-video"
+	class={`flex w-full justify-center divide-gray-100 border-gray-100 text-gray-700 dark:divide-gray-700 dark:border-gray-700 dark:text-gray-200 ${fitWorkingHours ? '' : 'md:aspect-video'}`}
 >
-	<div id="calendar" class="w-full" use:calendarAction />
+	<div id="calendar" class:staff-calendar={detailsEnabled} class="w-full" use:calendarAction />
 </div>
+
+<Modal bind:open={detailsOpen} title={selectedEvent?.title || 'Event details'} size="md" autoclose>
+	{#if selectedEvent}
+		<div class="space-y-5 text-left text-gray-700 dark:text-gray-200">
+			<p class="font-medium text-gray-900 dark:text-white">{formatEventTime(selectedEvent)}</p>
+
+			{#if selectedEvent.location}
+				<div>
+					<h4
+						class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+					>
+						Location
+					</h4>
+					<p class="mt-1 whitespace-pre-wrap">{selectedEvent.location}</p>
+				</div>
+			{/if}
+
+			<div>
+				<h4 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+					Details
+				</h4>
+				{#if selectedEvent.description}
+					<p class="mt-1 whitespace-pre-wrap">{selectedEvent.description}</p>
+				{:else}
+					<p class="mt-1 text-gray-500 dark:text-gray-400">No additional details were provided.</p>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</Modal>

--- a/frontend/src/lib/components/calendar.pcss
+++ b/frontend/src/lib/components/calendar.pcss
@@ -2,3 +2,12 @@
 	--fc-list-event-hover-bg-color: #0f172a;
 	--fc-page-bg-color: #0f172a;
 }
+
+.staff-calendar .fc-event {
+	cursor: pointer;
+}
+
+.staff-calendar .fc-event:focus-visible {
+	outline: 3px solid #2563eb;
+	outline-offset: 2px;
+}

--- a/frontend/src/lib/server/staffCalendarAccess.test.ts
+++ b/frontend/src/lib/server/staffCalendarAccess.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { requireStaffCalendarAccess } from '$lib/server/staffCalendarAccess';
+
+function leashUser(role: string) {
+	return {
+		ID: 7,
+		CreatedAt: '2026-01-01T00:00:00Z',
+		UpdatedAt: '2026-01-01T00:00:00Z',
+		Email: 'person@example.edu',
+		CardID: '',
+		Name: 'Person',
+		Pronouns: '',
+		Role: role,
+		Type: 'undergrad',
+		GraduationYear: 2028,
+		Major: '',
+		Department: '',
+		JobTitle: '',
+		Permissions: []
+	};
+}
+
+describe('staff calendar server authorization', () => {
+	it('rejects an unauthenticated request without calling Leash', async () => {
+		const fetch = vi.fn();
+		await expect(
+			requireStaffCalendarAccess({ token: undefined, leashURL: 'https://leash.example', fetch })
+		).rejects.toMatchObject({ status: 401 });
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it('rejects an authenticated ordinary member', async () => {
+		let requestInit: RequestInit | undefined;
+		const fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			requestInit = init;
+			return Response.json(leashUser('member'));
+		});
+		await expect(
+			requireStaffCalendarAccess({
+				token: 'member-token',
+				leashURL: 'https://leash.example',
+				fetch: fetch as typeof globalThis.fetch
+			})
+		).rejects.toMatchObject({ status: 403 });
+		expect(new Headers(requestInit?.headers).get('authorization')).toBe('Bearer member-token');
+	});
+
+	it.each(['volunteer', 'staff', 'admin'])('allows an authenticated %s account', async (role) => {
+		const fetch = vi.fn(async () => Response.json(leashUser(role)));
+		const user = await requireStaffCalendarAccess({
+			token: `${role}-token`,
+			leashURL: 'https://leash.example',
+			fetch: fetch as typeof globalThis.fetch
+		});
+		expect(user.role).toBe(role);
+		expect(user.isStaff).toBe(true);
+	});
+
+	it('treats an invalid or expired token as unauthenticated', async () => {
+		const fetch = vi.fn(async () => new Response('invalid token', { status: 401 }));
+		await expect(
+			requireStaffCalendarAccess({
+				token: 'expired-token',
+				leashURL: 'https://leash.example',
+				fetch: fetch as typeof globalThis.fetch
+			})
+		).rejects.toMatchObject({ status: 401 });
+	});
+});

--- a/frontend/src/lib/server/staffCalendarAccess.ts
+++ b/frontend/src/lib/server/staffCalendarAccess.ts
@@ -1,0 +1,45 @@
+import { error } from '@sveltejs/kit';
+import { LeashAPI, LeashAPIError, type User } from '$lib/leash';
+
+export interface StaffCalendarAccessOptions {
+	token: string | undefined;
+	leashURL: string | undefined;
+	fetch: typeof globalThis.fetch;
+}
+
+export async function requireStaffCalendarAccess({
+	token,
+	leashURL,
+	fetch
+}: StaffCalendarAccessOptions): Promise<User> {
+	if (!token) {
+		error(401, 'Authentication required.');
+	}
+	if (!leashURL) {
+		error(500, 'LEASH_ENDPOINT not set');
+	}
+
+	const api = new LeashAPI(token, leashURL);
+	api.overrideFetchFunction(fetch);
+
+	let user: User;
+	try {
+		// The user and role come from Leash on the server. Do not trust page data or
+		// a client-provided role when protecting a standalone JSON endpoint.
+		user = await api.selfUser({}, true);
+	} catch (caught) {
+		if (caught instanceof LeashAPIError && caught.status === 401) {
+			error(401, 'Authentication required.');
+		}
+		if (caught instanceof LeashAPIError && caught.status === 403) {
+			error(403, 'You do not have permission to access this resource.');
+		}
+		error(502, 'Error communicating with Leash.');
+	}
+
+	if (!user.isStaff) {
+		error(403, 'You do not have permission to access this resource.');
+	}
+
+	return user;
+}

--- a/frontend/src/lib/staffCalendarColors.test.ts
+++ b/frontend/src/lib/staffCalendarColors.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	COMMITTEE_EVENT_COLOR,
+	CURRENT_STAFF_NAMES,
+	STAFF_COLORS,
+	UNKNOWN_EVENT_COLOR,
+	createStaffCalendarColorizer
+} from '$lib/staffCalendarColors';
+
+describe('staff calendar color policy', () => {
+	it('assigns every current person the expected unique non-gray color', () => {
+		expect(STAFF_COLORS).toEqual({
+			Shira: '#9fc6e7',
+			Lauren: '#42d692',
+			Keegan: '#f83a22',
+			Jack: '#a47ae2',
+			Niall: '#cd74e6',
+			Julius: '#4986e7',
+			Tobias: '#f691b2',
+			Peyton: '#92e1c0',
+			Brody: '#fbe983',
+			Duy: '#b99aff',
+			Punya: '#fa573c',
+			Brooke: '#ff7537',
+			Rigel: '#b3dc6c',
+			Sean: '#ffad46',
+			Quinlan: '#fad165',
+			Marcelo: '#9a9cff',
+			Sastha: '#7bd148',
+			Ethan: '#16a765',
+			Tvisha: '#9fe1e7'
+		});
+		expect(CURRENT_STAFF_NAMES).toHaveLength(19);
+		expect(new Set(Object.values(STAFF_COLORS)).size).toBe(19);
+		expect(Object.values(STAFF_COLORS)).not.toContain(COMMITTEE_EVENT_COLOR);
+	});
+
+	it('normalizes case and whitespace without changing a person color', () => {
+		const colorize = createStaffCalendarColorizer();
+		expect(colorize({ title: 'Niall' }).backgroundColor).toBe(STAFF_COLORS.Niall);
+		expect(colorize({ title: '  NIALL\t' }).backgroundColor).toBe(STAFF_COLORS.Niall);
+		expect(colorize({ title: 'julius' }).backgroundColor).toBe(STAFF_COLORS.Julius);
+	});
+
+	it.each([
+		'Textiles',
+		'3DP',
+		'3D Printing',
+		'Electronics',
+		'Shop',
+		'Textiles Committee',
+		'Team meeting',
+		'Notes — fall schedule'
+	])('renders %s in committee gray', (title) => {
+		const event = createStaffCalendarColorizer()({ title });
+		expect(event.backgroundColor).toBe(COMMITTEE_EVENT_COLOR);
+	});
+
+	it('classifies only from the title, not from a shift description', () => {
+		const event = createStaffCalendarColorizer()({
+			title: 'Shira',
+			description: 'Attending a committee later'
+		});
+		expect(event.backgroundColor).toBe(STAFF_COLORS.Shira);
+	});
+
+	it('renders tours and other non-shifts gray while warning once per unknown title', () => {
+		const onUnknown = vi.fn();
+		const colorize = createStaffCalendarColorizer(onUnknown);
+		expect(colorize({ title: 'Transfer students quick tour' }).backgroundColor).toBe(
+			COMMITTEE_EVENT_COLOR
+		);
+		expect(colorize({ title: '  transfer   students quick tour ' }).backgroundColor).toBe(
+			UNKNOWN_EVENT_COLOR
+		);
+		expect(onUnknown).toHaveBeenCalledOnce();
+		expect(onUnknown).toHaveBeenCalledWith('Transfer students quick tour');
+	});
+
+	it('changes only display-color fields', () => {
+		const original = {
+			title: 'Brooke',
+			description: 'unchanged',
+			start: '2026-09-08T10:00:00-04:00',
+			end: '2026-09-08T13:00:00-04:00',
+			allDay: false,
+			id: 'calendar-uid',
+			uid: 'calendar-uid',
+			sequence: 4,
+			recurrenceId: '2026-09-08T10:00:00-04:00',
+			extendedProps: { source: 'Team calendar' }
+		};
+		const colored = createStaffCalendarColorizer()(original);
+		const { backgroundColor, borderColor, textColor, ...preserved } = colored;
+
+		expect(preserved).toEqual(original);
+		expect(backgroundColor).toBe(STAFF_COLORS.Brooke);
+		expect(borderColor).toBe(STAFF_COLORS.Brooke);
+		expect(textColor).toMatch(/^#[0-9a-f]{6}$/);
+	});
+});

--- a/frontend/src/lib/staffCalendarColors.ts
+++ b/frontend/src/lib/staffCalendarColors.ts
@@ -1,0 +1,102 @@
+import type { EventInput } from '@fullcalendar/core';
+
+export const COMMITTEE_EVENT_COLOR = '#c2c2c2';
+// Anything that is not an exact, recognized staff shift is gray. Unknown
+// titles still warn so a newly scheduled staff member can be added explicitly.
+export const UNKNOWN_EVENT_COLOR = COMMITTEE_EVENT_COLOR;
+
+// Frozen from the Fall 2026 Team-calendar overlap plan. Keep this explicit so a
+// new person cannot silently take an existing person's color.
+export const STAFF_COLORS = Object.freeze({
+	Shira: '#9fc6e7',
+	Lauren: '#42d692',
+	Keegan: '#f83a22',
+	Jack: '#a47ae2',
+	Niall: '#cd74e6',
+	Julius: '#4986e7',
+	Tobias: '#f691b2',
+	Peyton: '#92e1c0',
+	Brody: '#fbe983',
+	Duy: '#b99aff',
+	Punya: '#fa573c',
+	Brooke: '#ff7537',
+	Rigel: '#b3dc6c',
+	Sean: '#ffad46',
+	Quinlan: '#fad165',
+	Marcelo: '#9a9cff',
+	Sastha: '#7bd148',
+	Ethan: '#16a765',
+	Tvisha: '#9fe1e7'
+});
+
+export type StaffName = keyof typeof STAFF_COLORS;
+export const CURRENT_STAFF_NAMES = Object.freeze(Object.keys(STAFF_COLORS) as StaffName[]);
+
+const COLOR_BY_NORMALIZED_NAME: ReadonlyMap<string, string> = new Map(
+	CURRENT_STAFF_NAMES.map((name) => [normalizeCalendarTitle(name), STAFF_COLORS[name]])
+);
+
+const COMMITTEE_TITLES = new Set(['textiles', '3dp', '3d printing', 'electronics', 'shop']);
+
+export function normalizeCalendarTitle(title: string): string {
+	return title.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function isCommitteeMeetingOrNote(title: string): boolean {
+	const normalized = normalizeCalendarTitle(title);
+	return (
+		COMMITTEE_TITLES.has(normalized) ||
+		/(?:^|\s)(?:committee|meeting)(?:$|\s|[\u2014\u2013:|/-])/.test(normalized) ||
+		/^notes?(?:$|\s|[\u2014\u2013:|/-])/.test(normalized)
+	);
+}
+
+function textColorFor(backgroundColor: string): '#000000' | '#ffffff' {
+	const channels = [1, 3, 5].map((index) =>
+		Number.parseInt(backgroundColor.slice(index, index + 2), 16)
+	);
+	const luminance = channels
+		.map((channel) => channel / 255)
+		.map((channel) =>
+			channel <= 0.04045 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4)
+		)
+		.reduce((sum, channel, index) => sum + channel * [0.2126, 0.7152, 0.0722][index], 0);
+
+	const whiteContrast = 1.05 / (luminance + 0.05);
+	const blackContrast = (luminance + 0.05) / 0.05;
+	return blackContrast >= whiteContrast ? '#000000' : '#ffffff';
+}
+
+export function createStaffCalendarColorizer(
+	onUnknownTitle: (title: string) => void = (title) =>
+		console.warn(`Unmapped staff calendar title: ${JSON.stringify(title)}`)
+): (event: EventInput) => EventInput {
+	const warnedTitles = new Set<string>();
+
+	return (event: EventInput): EventInput => {
+		const title = event.title ?? '';
+		const normalized = normalizeCalendarTitle(title);
+		let backgroundColor: string | undefined = COLOR_BY_NORMALIZED_NAME.get(normalized);
+
+		if (!backgroundColor && isCommitteeMeetingOrNote(title)) {
+			backgroundColor = COMMITTEE_EVENT_COLOR;
+		}
+
+		if (!backgroundColor) {
+			backgroundColor = UNKNOWN_EVENT_COLOR;
+			if (!warnedTitles.has(normalized)) {
+				warnedTitles.add(normalized);
+				onUnknownTitle(title);
+			}
+		}
+
+		return {
+			...event,
+			backgroundColor,
+			borderColor: backgroundColor,
+			textColor: textColorFor(backgroundColor)
+		};
+	};
+}
+
+export const colorizeStaffCalendarEvent = createStaffCalendarColorizer();

--- a/frontend/src/routes/(authenticated)/staff/+page.svelte
+++ b/frontend/src/routes/(authenticated)/staff/+page.svelte
@@ -1,69 +1,73 @@
 <script lang="ts">
 	import Calendar from '$lib/components/Calendar.svelte';
-	import { Heading, P } from 'flowbite-svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
 </script>
 
-<div class="flex flex-col items-center justify-center gap-12 text-center md:px-16">
-	<Heading tag="h1" class="mb-4" customSize="text-4xl font-extrabold  md:text-5xl lg:text-6xl"
-		>Welcome to the Staff Portal</Heading
-	>
-	<P class="mb-6 text-lg dark:text-gray-400 sm:px-16 lg:text-xl xl:px-48"
-		>Access staff resources here.</P
-	>
-	{#if data.user.canListFeeds}
-		<a
-			href="/staff/feeds/1"
-			class="group w-full max-w-2xl rounded-2xl border border-blue-200 bg-blue-50 p-6 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-blue-200 dark:border-blue-900 dark:bg-blue-950 dark:focus:ring-blue-900"
+<div class="w-full space-y-10 px-2 pb-12 md:px-6">
+	<section aria-labelledby="staff-calendar-heading">
+		<header class="mb-5 text-left">
+			<h1 id="staff-calendar-heading" class="text-3xl font-bold text-gray-950 dark:text-white">
+				Staff calendar
+			</h1>
+			<p class="mt-1 text-gray-600 dark:text-gray-300">
+				Shifts are color-coded; tours and other events are gray. Select any event for its details.
+			</p>
+		</header>
+
+		<Calendar url="/staff/calendar" detailsEnabled fitWorkingHours />
+	</section>
+
+	{#if data.user.canListFeeds || data.user.canExportCheckins}
+		<section
+			class="border-t border-gray-200 pt-8 dark:border-gray-700"
+			aria-labelledby="staff-tools-heading"
 		>
-			<span
-				class="text-sm font-semibold uppercase tracking-[0.16em] text-blue-700 dark:text-blue-300"
-				>Live staff tool</span
-			>
-			<span class="mt-2 flex items-center justify-between gap-4">
-				<span>
-					<span class="block text-2xl font-bold text-gray-950 dark:text-white"
-						>Front Desk Check-in HUD</span
+			<h2 id="staff-tools-heading" class="mb-4 text-xl font-semibold text-gray-950 dark:text-white">
+				Staff tools
+			</h2>
+			<div class="grid gap-3 md:grid-cols-2">
+				{#if data.user.canListFeeds}
+					<a
+						href="/staff/feeds/1"
+						class="group flex items-center justify-between gap-4 rounded-xl border border-blue-200 bg-blue-50 p-4 text-left transition hover:border-blue-400 hover:shadow-sm focus:outline-none focus:ring-4 focus:ring-blue-200 dark:border-blue-900 dark:bg-blue-950 dark:focus:ring-blue-900"
 					>
-					<span class="mt-1 block text-gray-700 dark:text-gray-200"
-						>Monitor card taps and participation-agreement status in real time.</span
+						<span>
+							<span class="block text-lg font-semibold text-gray-950 dark:text-white"
+								>Front Desk Check-in HUD</span
+							>
+							<span class="mt-1 block text-sm text-gray-700 dark:text-gray-200"
+								>Monitor card taps and participation-agreement status.</span
+							>
+						</span>
+						<span
+							aria-hidden="true"
+							class="text-2xl text-blue-700 transition group-hover:translate-x-1">→</span
+						>
+					</a>
+				{/if}
+
+				{#if data.user.canExportCheckins}
+					<a
+						href="/staff/checkins"
+						class="group flex items-center justify-between gap-4 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-left transition hover:border-emerald-400 hover:shadow-sm focus:outline-none focus:ring-4 focus:ring-emerald-200 dark:border-emerald-900 dark:bg-emerald-950 dark:focus:ring-emerald-900"
 					>
-				</span>
-				<span aria-hidden="true" class="text-3xl text-blue-700 transition group-hover:translate-x-1"
-					>→</span
-				>
-			</span>
-		</a>
+						<span>
+							<span class="block text-lg font-semibold text-gray-950 dark:text-white"
+								>Check-in Data Export</span
+							>
+							<span class="mt-1 block text-sm text-gray-700 dark:text-gray-200"
+								>Download privacy-safe card-tap data.</span
+							>
+						</span>
+						<span
+							aria-hidden="true"
+							class="text-2xl text-emerald-700 transition group-hover:translate-x-1">→</span
+						>
+					</a>
+				{/if}
+			</div>
+		</section>
 	{/if}
-	{#if data.user.canExportCheckins}
-		<a
-			href="/staff/checkins"
-			class="group w-full max-w-2xl rounded-2xl border border-emerald-200 bg-emerald-50 p-6 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-emerald-200 dark:border-emerald-900 dark:bg-emerald-950 dark:focus:ring-emerald-900"
-		>
-			<span
-				class="text-sm font-semibold uppercase tracking-[0.16em] text-emerald-700 dark:text-emerald-300"
-				>Restricted data tool</span
-			>
-			<span class="mt-2 flex items-center justify-between gap-4">
-				<span>
-					<span class="block text-2xl font-bold text-gray-950 dark:text-white"
-						>Check-in Data Export</span
-					>
-					<span class="mt-1 block text-gray-700 dark:text-gray-200"
-						>Download card-tap events with stable, privacy-safe member UUIDs.</span
-					>
-				</span>
-				<span
-					aria-hidden="true"
-					class="text-3xl text-emerald-700 transition group-hover:translate-x-1">→</span
-				>
-			</span>
-		</a>
-	{/if}
-	<div class="flex w-full flex-col items-center justify-center">
-		<P class="mb-6 text-lg dark:text-gray-400 sm:px-16 lg:text-xl xl:px-48">Staff hours.</P>
-		<Calendar url="/staff/calendar" />
-	</div>
 </div>

--- a/frontend/src/routes/(authenticated)/staff/calendar/+server.ts
+++ b/frontend/src/routes/(authenticated)/staff/calendar/+server.ts
@@ -1,52 +1,89 @@
 import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { env } from '$env/dynamic/private';
+import { env as privateEnv } from '$env/dynamic/private';
+import { env as publicEnv } from '$env/dynamic/public';
 import { CalendarServer } from '$lib/calendarServer';
-import { generateColor } from '@marko19907/string-to-color';
-import type { EventInput } from '@fullcalendar/core/index.js';
+import { colorizeStaffCalendarEvent } from '$lib/staffCalendarColors';
+import {
+	requireStaffCalendarAccess,
+	type StaffCalendarAccessOptions
+} from '$lib/server/staffCalendarAccess';
 
-let calendar: CalendarServer | undefined = undefined;
+interface CalendarReader {
+	getEventsBetween(start: Date, end: Date): ReturnType<CalendarServer['getEventsBetween']>;
+}
 
-const colorize = (event: EventInput) => {
-	if (event.title === undefined) return event;
+interface StaffCalendarHandlerContext {
+	fetch: typeof globalThis.fetch;
+	url: URL;
+	cookies: { get(name: string): string | undefined };
+}
 
-	return {
-		...event,
-		color: generateColor(event.title)
-	};
-};
+interface StaffCalendarHandlerDependencies {
+	getCalendarEndpoint: () => string | undefined;
+	getLeashEndpoint: () => string | undefined;
+	authorize: (options: StaffCalendarAccessOptions) => Promise<unknown>;
+	createCalendar: (endpoint: string, fetch: typeof globalThis.fetch) => CalendarReader;
+}
 
-export const GET: RequestHandler = async ({ fetch, url }) => {
-	if (!calendar) {
-		const cal = env.STAFF_CALENDAR_ENDPOINT;
-		if (!cal) {
-			error(500, 'No calendar endpoint configured.');
-		}
+export function _createStaffCalendarHandler(
+	dependencies: StaffCalendarHandlerDependencies
+): (context: StaffCalendarHandlerContext) => Promise<Response> {
+	let calendar: CalendarReader | undefined;
 
-		calendar = new CalendarServer(cal, fetch, colorize);
-	}
-
-	const start = url.searchParams.get('start');
-	if (!start) error(400, 'No start date provided');
-
-	const end = url.searchParams.get('end');
-	if (!end) error(400, 'No end date provided');
-
-	let data;
-
-	try {
-		data = await calendar.getEventsBetween(new Date(start || ''), new Date(end || ''));
-	} catch (e) {
-		calendar = undefined;
-		console.error(e);
-		error(500, {
-			message: 'Internal Service Error'
+	return async ({ fetch, url, cookies }) => {
+		await dependencies.authorize({
+			token: cookies.get('token'),
+			leashURL: dependencies.getLeashEndpoint(),
+			fetch
 		});
-	}
 
-	return new Response(JSON.stringify(data), {
-		headers: {
-			'Content-Type': 'text/calendar'
+		const startParam = url.searchParams.get('start');
+		if (!startParam) error(400, 'No start date provided');
+
+		const endParam = url.searchParams.get('end');
+		if (!endParam) error(400, 'No end date provided');
+
+		const start = new Date(startParam);
+		const end = new Date(endParam);
+		if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime()) || end <= start) {
+			error(400, 'Invalid calendar date range');
 		}
-	});
-};
+
+		if (!calendar) {
+			const endpoint = dependencies.getCalendarEndpoint();
+			if (!endpoint) {
+				error(500, 'No calendar endpoint configured.');
+			}
+			calendar = dependencies.createCalendar(endpoint, fetch);
+		}
+
+		let data;
+		try {
+			data = await calendar.getEventsBetween(start, end);
+		} catch {
+			calendar = undefined;
+			// Fetch errors can contain the private ICS URL, so do not log the caught value.
+			console.error('Failed to read staff calendar data.');
+			error(500, 'Internal Service Error');
+		}
+
+		return new Response(JSON.stringify(data), {
+			headers: {
+				'Content-Type': 'application/json',
+				'Cache-Control': 'private, no-store'
+			}
+		});
+	};
+}
+
+const staffCalendarHandler = _createStaffCalendarHandler({
+	getCalendarEndpoint: () => privateEnv.STAFF_CALENDAR_ENDPOINT,
+	getLeashEndpoint: () => publicEnv.PUBLIC_LEASH_ENDPOINT,
+	authorize: requireStaffCalendarAccess,
+	createCalendar: (endpoint, fetch) =>
+		new CalendarServer(endpoint, fetch, colorizeStaffCalendarEvent)
+});
+
+export const GET: RequestHandler = async ({ fetch, url, cookies }) =>
+	staffCalendarHandler({ fetch, url, cookies });

--- a/frontend/src/routes/(authenticated)/staff/calendar/server.test.ts
+++ b/frontend/src/routes/(authenticated)/staff/calendar/server.test.ts
@@ -1,0 +1,65 @@
+import { error } from '@sveltejs/kit';
+import { describe, expect, it, vi } from 'vitest';
+import { _createStaffCalendarHandler } from './+server';
+
+const secretEndpoint = 'https://calendar.example/private-secret.ics';
+
+function context(token: string | undefined) {
+	return {
+		fetch: vi.fn() as unknown as typeof globalThis.fetch,
+		url: new URL('https://mkr.cx/staff/calendar?start=2026-09-08&end=2026-09-09'),
+		cookies: { get: () => token }
+	};
+}
+
+function handlerForRole(role: 'anonymous' | 'member' | 'staff') {
+	const createCalendar = vi.fn(() => ({
+		getEventsBetween: vi.fn(async () => [
+			{
+				title: 'Niall',
+				start: '2026-09-08T09:00:00-04:00',
+				end: '2026-09-08T17:00:00-04:00',
+				backgroundColor: '#cd74e6'
+			}
+		])
+	}));
+	const handler = _createStaffCalendarHandler({
+		getCalendarEndpoint: () => secretEndpoint,
+		getLeashEndpoint: () => 'https://leash.example',
+		authorize: async () => {
+			if (role === 'anonymous') error(401, 'Authentication required.');
+			if (role === 'member') error(403, 'Forbidden.');
+		},
+		createCalendar
+	});
+	return { handler, createCalendar };
+}
+
+describe('/staff/calendar endpoint', () => {
+	it('rejects a logged-out request before reading the private calendar', async () => {
+		const { handler, createCalendar } = handlerForRole('anonymous');
+		await expect(handler(context(undefined))).rejects.toMatchObject({ status: 401 });
+		expect(createCalendar).not.toHaveBeenCalled();
+	});
+
+	it('rejects an authenticated non-staff member before reading the private calendar', async () => {
+		const { handler, createCalendar } = handlerForRole('member');
+		await expect(handler(context('member-token'))).rejects.toMatchObject({ status: 403 });
+		expect(createCalendar).not.toHaveBeenCalled();
+	});
+
+	it('returns private, read-only JSON to an authenticated staff account without exposing the source URL', async () => {
+		const { handler, createCalendar } = handlerForRole('staff');
+		const response = await handler(context('staff-token'));
+		const body = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toContain('application/json');
+		expect(response.headers.get('cache-control')).toBe('private, no-store');
+		expect(JSON.parse(body)).toEqual([
+			expect.objectContaining({ title: 'Niall', backgroundColor: '#cd74e6' })
+		]);
+		expect(body).not.toContain(secretEndpoint);
+		expect(createCalendar).toHaveBeenCalledWith(secretEndpoint, expect.any(Function));
+	});
+});


### PR DESCRIPTION
## Summary

- Restrict the staff-calendar data endpoint to logged-in staff.
- Return 401 when logged out and 403 for non-staff accounts.
- Give each current staff member a fixed shift color.
- Display tours, meetings, closures, notes, and other non-shifts in gray.
- Display unrecognized shift names in gray and issue a developer warning.
- Keep the calendar read-only and prevent private response caching.
- Keep the underlying calendar URL secret.

## Verification

- All 41 automated tests pass.
- Changed-file linting passes.
- Production frontend build passes.
- The four existing type errors in `frontend/src/lib/calendar.ts` are unchanged and unrelated.

## Deployment

This pull request does not deploy anything. It changes only the frontend calendar behavior. No Google Calendar events, permissions, account roles, databases, secrets, or infrastructure are changed.

Staff-account role verification remains required before production deployment.