### PR TITLE
Repair native multi-platform CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,20 @@
-# Based heavily on the docker build action from immich (https://github.com/immich-app/immich/)
+# Based heavily on the Docker multi-platform GitHub Actions guidance:
+# https://docs.docker.com/build/ci/github-actions/multi-platform/
 
 name: Docker
 
 on:
   workflow_dispatch:
+    inputs:
+      component:
+        description: Component to publish
+        required: true
+        default: both
+        type: choice
+        options:
+          - frontend
+          - backend
+          - both
   push:
     branches: [main]
   pull_request:
@@ -13,19 +24,49 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Determine Changed Components
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+    steps:
+      - name: Filter pull-request paths
+        id: filter
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+            frontend:
+              - 'frontend/**'
+            workflow:
+              - '.github/workflows/docker.yml'
+
   test-backend:
     name: Test Backend
-    runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.workflow == 'true') &&
+        (github.event_name != 'workflow_dispatch' || inputs.component == 'backend' || inputs.component == 'both')
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.21.x"
           cache-dependency-path: ./backend/go.sum
@@ -35,14 +76,24 @@ jobs:
       - name: Test Leash
         working-directory: ./backend
         run: go test ./...
+      - name: Build Leash
+        working-directory: ./backend
+        run: go build ./...
 
   test-frontend:
     name: Test Frontend
-    runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.workflow == 'true') &&
+        (github.event_name != 'workflow_dispatch' || inputs.component == 'frontend' || inputs.component == 'both')
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
       - name: Install pnpm
@@ -56,48 +107,20 @@ jobs:
       - name: Test Frontend Units
         working-directory: ./frontend
         run: pnpm run test:unit -- --run
+      - name: Check Frontend Types
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.frontend == 'true' }}
+        working-directory: ./frontend
+        run: pnpm run check
+      - name: Build Frontend
+        working-directory: ./frontend
+        run: pnpm run build
 
-  build-pr:
-    name: Build PR (no publish)
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    needs: [test-backend, test-frontend]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: mkrcx-leash
-            context: backend
-            file: backend/src/leash/Dockerfile
-            platforms: linux/amd64,linux/arm64
-          - image: mkrcx-frontend
-            context: frontend
-            file: frontend/Dockerfile
-            platforms: linux/amd64,linux/arm64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
-      - name: Build image without publishing
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
-          platforms: ${{ matrix.platforms }}
-          push: false
-          tags: local/${{ matrix.image }}:pr-${{ github.event.pull_request.number }}
-
-  build-and-push:
-    name: Build and Push
+  build-frontend:
+    name: Build Frontend (${{ matrix.arch }})
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
-    needs: [test-backend, test-frontend]
+    needs: test-frontend
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write
@@ -105,57 +128,325 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: mkrcx-leash
-            context: backend
-            file: backend/src/leash/Dockerfile
-            platforms: linux/amd64,linux/arm64
-          - image: mkrcx-frontend
-            context: frontend
-            file: frontend/Dockerfile
-            platforms: linux/amd64,linux/arm64
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+            uname: x86_64
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            uname: aarch64
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify native runner architecture
+        run: test "$(uname -m)" = "${{ matrix.uname }}"
       - name: Login to Docker Hub
         if: ${{ github.event_name == 'release' }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ env.ACT && github.actor || github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate docker image tags
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Generate Docker image metadata
         id: metadata
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           flavor: |
             latest=auto
           images: |
-            name=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
-            name=umassmakerspace/${{ matrix.image }},enable=${{ github.event_name == 'release' }}
+            name=ghcr.io/${{ github.repository_owner }}/mkrcx-frontend
+            name=umassmakerspace/mkrcx-frontend,enable=${{ github.event_name == 'release' }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
             type=raw,value=release,enable=${{ github.event_name == 'release' }}
-      - name: Build and push image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      - name: Select image repositories
+        id: images
+        env:
+          GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/mkrcx-frontend
+          DOCKERHUB_IMAGE: umassmakerspace/mkrcx-frontend
+        run: |
+          names="$GHCR_IMAGE"
+          if test "$GITHUB_EVENT_NAME" = release; then
+            names="${names},${DOCKERHUB_IMAGE}"
+          fi
+          echo "names=$names" >> "$GITHUB_OUTPUT"
+      - name: Select cache destination
+        id: cache
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+        run: echo "to=type=registry,mode=max,ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/mkrcx-build-cache:mkrcx-frontend-${{ matrix.arch }}-main" >> "$GITHUB_OUTPUT"
+      - name: Build and push native image by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
-          platforms: ${{ matrix.platforms }}
-          push: true
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mkrcx-build-cache:${{ matrix.image }}
-          cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/mkrcx-build-cache:${{ matrix.image }}
-          tags: ${{ steps.metadata.outputs.tags }}
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/mkrcx-build-cache:mkrcx-frontend-${{ matrix.arch }}-main
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/mkrcx-build-cache:mkrcx-frontend
+          cache-to: ${{ steps.cache.outputs.to }}
+          outputs: type=image,"name=${{ steps.images.outputs.names }}",push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: frontend-digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-frontend:
+    name: Publish Frontend Manifest
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: build-frontend
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: frontend-digests-*
+          merge-multiple: true
+      - name: Login to Docker Hub
+        if: ${{ github.event_name == 'release' }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ env.ACT && github.actor || github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Generate Docker image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          flavor: |
+            latest=auto
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/mkrcx-frontend
+            name=umassmakerspace/mkrcx-frontend,enable=${{ github.event_name == 'release' }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=release,enable=${{ github.event_name == 'release' }}
+      - name: Create and inspect manifest
+        env:
+          DIGEST_DIR: ${{ runner.temp }}/digests
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.metadata.outputs.json }}
+          GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/mkrcx-frontend
+          PRIMARY_VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          shopt -s nullglob
+          digest_files=("$DIGEST_DIR"/*)
+          test "${#digest_files[@]}" -eq 2
+
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          test "${#tags[@]}" -gt 0
+
+          for tag in "${tags[@]}"; do
+            repository="${tag%:*}"
+            sources=()
+            for digest_file in "${digest_files[@]}"; do
+              sources+=("${repository}@sha256:$(basename "$digest_file")")
+            done
+            docker buildx imagetools create -t "$tag" "${sources[@]}"
+          done
+
+          canonical_tag="${GHCR_IMAGE}:${PRIMARY_VERSION}"
+          raw_manifest="$(docker buildx imagetools inspect --raw "$canonical_tag")"
+          jq -e '
+            [.manifests[] | select(.platform.os == "linux") | .platform.architecture] | sort == ["amd64", "arm64"]
+          ' <<< "$raw_manifest"
+          docker buildx imagetools inspect "$canonical_tag"
+
+  build-backend:
+    name: Build Backend (${{ matrix.arch }})
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: test-backend
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+            uname: x86_64
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            uname: aarch64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify native runner architecture
+        run: test "$(uname -m)" = "${{ matrix.uname }}"
+      - name: Login to Docker Hub
+        if: ${{ github.event_name == 'release' }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ env.ACT && github.actor || github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Generate Docker image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          flavor: |
+            latest=auto
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/mkrcx-leash
+            name=umassmakerspace/mkrcx-leash,enable=${{ github.event_name == 'release' }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=release,enable=${{ github.event_name == 'release' }}
+      - name: Select image repositories
+        id: images
+        env:
+          GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/mkrcx-leash
+          DOCKERHUB_IMAGE: umassmakerspace/mkrcx-leash
+        run: |
+          names="$GHCR_IMAGE"
+          if test "$GITHUB_EVENT_NAME" = release; then
+            names="${names},${DOCKERHUB_IMAGE}"
+          fi
+          echo "names=$names" >> "$GITHUB_OUTPUT"
+      - name: Select cache destination
+        id: cache
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+        run: echo "to=type=registry,mode=max,ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/mkrcx-build-cache:mkrcx-leash-${{ matrix.arch }}-main" >> "$GITHUB_OUTPUT"
+      - name: Build and push native image by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./backend
+          file: ./backend/src/leash/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/mkrcx-build-cache:mkrcx-leash-${{ matrix.arch }}-main
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/mkrcx-build-cache:mkrcx-leash
+          cache-to: ${{ steps.cache.outputs.to }}
+          outputs: type=image,"name=${{ steps.images.outputs.names }}",push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: backend-digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-backend:
+    name: Publish Backend Manifest
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: build-backend
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: backend-digests-*
+          merge-multiple: true
+      - name: Login to Docker Hub
+        if: ${{ github.event_name == 'release' }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ env.ACT && github.actor || github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Generate Docker image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          flavor: |
+            latest=auto
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/mkrcx-leash
+            name=umassmakerspace/mkrcx-leash,enable=${{ github.event_name == 'release' }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=release,enable=${{ github.event_name == 'release' }}
+      - name: Create and inspect manifest
+        env:
+          DIGEST_DIR: ${{ runner.temp }}/digests
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.metadata.outputs.json }}
+          GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/mkrcx-leash
+          PRIMARY_VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          shopt -s nullglob
+          digest_files=("$DIGEST_DIR"/*)
+          test "${#digest_files[@]}" -eq 2
+
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          test "${#tags[@]}" -gt 0
+
+          for tag in "${tags[@]}"; do
+            repository="${tag%:*}"
+            sources=()
+            for digest_file in "${digest_files[@]}"; do
+              sources+=("${repository}@sha256:$(basename "$digest_file")")
+            done
+            docker buildx imagetools create -t "$tag" "${sources[@]}"
+          done
+
+          canonical_tag="${GHCR_IMAGE}:${PRIMARY_VERSION}"
+          raw_manifest="$(docker buildx imagetools inspect --raw "$canonical_tag")"
+          jq -e '
+            [.manifests[] | select(.platform.os == "linux") | .platform.architecture] | sort == ["amd64", "arm64"]
+          ' <<< "$raw_manifest"
+          docker buildx imagetools inspect "$canonical_tag"


### PR DESCRIPTION
## Summary

- Replace emulated multi-platform builds with native AMD64 and ARM64 runners.
- Keep pull-request feedback lightweight with path-filtered application checks.
- Allow manual frontend-only, backend-only, or combined publishing.
- Publish by digest, assemble the final manifest only after both native builds pass, and verify both platforms.
- Update all pinned actions to current Node 24 releases, reuse trusted registry caches, and enforce timeouts.

## Local verification

- actionlint 1.7.12
- frontend ESLint
- 18 frontend unit tests
- production frontend build
- signed commit

This pull request does not deploy or change staging or production.